### PR TITLE
refactor(pig-latin): use Cow instead of always returning an owed value

### DIFF
--- a/pig_latin/src/pig_latin.rs
+++ b/pig_latin/src/pig_latin.rs
@@ -1,17 +1,20 @@
-pub(crate) fn pig_latin(original_word: &str) -> String {
+use std::borrow::Cow;
+
+pub(crate) fn pig_latin(original_word: &str) -> Cow<str> {
     if original_word.is_empty() {
-        return String::new();
+        return Cow::Borrowed("");
     }
 
     let first_char = original_word.chars().next().unwrap();
     if !first_char.is_ascii_alphabetic() {
-        return original_word.to_string();
+        return Cow::Borrowed(original_word);
     }
 
     if is_vowel(&first_char) {
-        format!("{original_word}-hay")
+        Cow::Owned(format!("{original_word}-hay"))
     } else {
-        format!("{}-{first_char}ay", &original_word[1..])
+        let rest = &original_word[1..];
+        Cow::Owned(format!("{rest}-{first_char}ay"))
     }
 }
 


### PR DESCRIPTION
The `Cow` (short for "Clone on Write") type can be really useful for scenarios like this where you want to optimize for performance by avoiding unnecessary allocations when possible.

In Rust, `Cow` allows you to use either a borrowed reference (`&str`) or an owned value (`String`) based on need. This can be especially helpful when you want to avoid cloning data unless absolutely necessary.

For your `pig_latin` function, here’s how `Cow` might be helpful:
- If the input string doesn't need modification (e.g., starts with a vowel), you could return a borrowed reference (`&str`).
- If the string does need modification (e.g., starts with a consonant), you can create a new `String` and have `Cow` handle it as owned data.

This way, you avoid creating a new `String` when it's unnecessary, which could improve performance in certain cases.

Here's a high-level idea of how you could refactor your function to use `Cow`:

```rust
use std::borrow::Cow;

pub(crate) fn pig_latin(original_word: &str) -> Cow<str> {
    if original_word.is_empty() {
        return Cow::Borrowed("");
    }

    let first_char = original_word.chars().next().unwrap();
    if !first_char.is_alphabetic() {
        return Cow::Borrowed(original_word);
    }

    if is_vowel(first_char) {
        Cow::Borrowed(format!("{original_word}-hay").as_str())
    } else {
        let rest = &original_word[1..];
        Cow::Owned(format!("{rest}-{first_char}ay"))
    }
}
```

This approach can help you manage both borrowed and owned data efficiently. Let me know if you'd like to dive deeper into implementing this, or if you have more questions about `Cow`!