### PR TITLE
refactor(org_employee_cli): extract a run function that allow for hijacking the IO so that we can write an integration test

### DIFF
--- a/org_employee_cli/src/main.rs
+++ b/org_employee_cli/src/main.rs
@@ -10,14 +10,14 @@ use std::io::{BufRead, Write};
 use Command::{AddEmployee, Exit, Invalid};
 
 fn main() {
+    println!("Welcome to Org Employee CLI. Enter a command.");
+    io::stdout().flush().unwrap();
+
     run(io::stdin().lock(), io::stdout().lock());
 }
 
 fn run<R: BufRead, W: Write>(input: R, mut output: W) {
     let mut company = Company::new();
-
-    writeln!(output, "Welcome to Org Employee CLI. Enter a command.").unwrap();
-    output.flush().unwrap();
 
     for line in input.lines() {
         let command = line.expect("Failed to read line");
@@ -27,7 +27,6 @@ fn run<R: BufRead, W: Write>(input: R, mut output: W) {
             AddEmployee { name, department } => {
                 company.add(name.clone(), department.clone());
                 writeln!(output, "Added {} to {}.", name, department).unwrap();
-                writeln!(output, "{:?}", company).unwrap();
             }
             Exit => {
                 writeln!(output, "Goodbye!").unwrap();
@@ -91,7 +90,7 @@ mod tests {
         run(Cursor::new(input_data), &mut output);
 
         let output_str = String::from_utf8(output).expect("Failed to convert output to String");
-        let expected_output = "Welcome to Org Employee CLI. Enter a command.\nAdded Alice to Engineering.\nCompany { employees: {\"Engineering\": [\"Alice\"]} }\nAdded Bob to Sales.\nCompany { employees: {\"Sales\": [\"Bob\"], \"Engineering\": [\"Alice\"]} }\nGoodbye!\n";
+        let expected_output = "Added Alice to Engineering.\nAdded Bob to Sales.\nGoodbye!\n";
 
         assert_eq!(output_str, expected_output);
     }

--- a/org_employee_cli/src/main.rs
+++ b/org_employee_cli/src/main.rs
@@ -135,7 +135,7 @@ mod tests {
     use std::io::Cursor;
 
     #[test]
-    fn test_integration_add_employee() {
+    fn add_employees() {
         let input_data = "add Alice to Engineering\nadd Bob to Sales\nexit\n";
         let mut output = Vec::new();
 
@@ -144,6 +144,19 @@ mod tests {
         assert_equals(
             output,
             "Added Alice to Engineering.\nAdded Bob to Sales.\nGoodbye!\n",
+        );
+    }
+
+    #[test]
+    fn list_all() {
+        let input_data = "add Bob to Engineering\nadd Anna to Sales\nlist all\nexit\n";
+        let mut output = Vec::new();
+
+        run(Cursor::new(input_data), &mut output);
+
+        assert_equals(
+            output,
+            "Added Bob to Engineering.\nAdded Anna to Sales.\n[\"Anna\", \"Bob\"]\nGoodbye!\n",
         );
     }
 

--- a/org_employee_cli/src/main.rs
+++ b/org_employee_cli/src/main.rs
@@ -89,9 +89,14 @@ mod tests {
 
         run(Cursor::new(input_data), &mut output);
 
-        let output_str = String::from_utf8(output).expect("Failed to convert output to String");
-        let expected_output = "Added Alice to Engineering.\nAdded Bob to Sales.\nGoodbye!\n";
+        assert_equals(
+            output,
+            "Added Alice to Engineering.\nAdded Bob to Sales.\nGoodbye!\n",
+        );
+    }
 
-        assert_eq!(output_str, expected_output);
+    fn assert_equals(output: Vec<u8>, expected_output: &str) {
+        let actual_output = String::from_utf8(output).expect("Failed to convert output to String");
+        assert_eq!(actual_output, expected_output);
     }
 }


### PR DESCRIPTION
To write an integration test verifying the functionality of the program end to end, we have to capture input and output, which can be challenging with a program that directly interacts with the console (`stdin` and `stdout`). To facilitate this, we can refactor the `main` function to make testing easier by providing an interface that can accept input and output arguments.

